### PR TITLE
Remove stupid unnused variable (vmem)

### DIFF
--- a/lspec
+++ b/lspec
@@ -9,7 +9,6 @@ NC='\033[0m' # No Color
 mem=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024)))
 cpumodel=$(lscpu | grep 'Model name' | cut -f 2 -d ":" | awk '{$1=$1}1')
 readarray -t gpuarray <<< $(lspci | grep VGA | cut -d ":" -f3 | cut -d " " -f 2-)
-RAM=$(cardid=$(lspci | grep VGA |cut -d " " -f1);lspci -v -s $cardid | grep " prefetchable"| cut -d "=" -f2)
 os=$(cat /etc/*-release | grep "PRETTY_NAME" | sed 's/PRETTY_NAME=//g' | sed 's/"//g')
 kernel=$(uname -r)
 proc=$(nproc)


### PR DESCRIPTION
The vmem calculation took a few seconds on some systems, as well as completely messing up output on multi-gpu systems